### PR TITLE
Fix typo in feedContent replace()

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ Meteor.methods({
 
   fetchRss: function() {
     feed = Feeds.findOne();
-    feedContent = HTTP.get("http://simplecast.fm/podcasts/1405/rss").content.replace('http://simplecast.fm/podcasts/1405/rss', 'http://podcast.creater.io/feed');
+    feedContent = HTTP.get("http://simplecast.fm/podcasts/1405/rss").content.replace('https://simplecast.fm/podcasts/1405/rss', 'http://podcast.crater.io/feed');
     if (feed) {
       Feeds.update(feed._id, {$set: {content: feedContent}});
     } else {


### PR DESCRIPTION
1. creater -> crater
2. simplecast feed redirects to https, so this replacement was never happening, typo included